### PR TITLE
!tm:adc:TM_ADC_InitADC:RCC - avoid all ADC clocks enable

### DIFF
--- a/00-STM32_LIBRARIES/tm_stm32_adc.c
+++ b/00-STM32_LIBRARIES/tm_stm32_adc.c
@@ -90,13 +90,19 @@ void TM_ADC_Init(ADC_TypeDef* ADCx, TM_ADC_Channel_t channel) {
 void TM_ADC_InitADC(ADC_TypeDef* ADCx) {
 	/* Enable clock */
 #if defined(ADC1)
-	__HAL_RCC_ADC1_CLK_ENABLE();
+	if (ADCx == ADC1){
+		__HAL_RCC_ADC1_CLK_ENABLE();
+	}
 #endif
 #if defined(ADC2)
-	__HAL_RCC_ADC2_CLK_ENABLE();
+	if (ADCx == ADC2){
+		__HAL_RCC_ADC2_CLK_ENABLE();
+	}
 #endif
 #if defined(ADC3)
-	__HAL_RCC_ADC3_CLK_ENABLE();
+	if (ADCx == ADC3){
+		__HAL_RCC_ADC3_CLK_ENABLE();
+	}
 #endif
 	
 	/* Configure the ADC peripheral */

--- a/00-STM32_LIBRARIES/tm_stm32_adc.c
+++ b/00-STM32_LIBRARIES/tm_stm32_adc.c
@@ -90,17 +90,17 @@ void TM_ADC_Init(ADC_TypeDef* ADCx, TM_ADC_Channel_t channel) {
 void TM_ADC_InitADC(ADC_TypeDef* ADCx) {
 	/* Enable clock */
 #if defined(ADC1)
-	if (ADCx == ADC1){
+	if (ADCx == ADC1) {
 		__HAL_RCC_ADC1_CLK_ENABLE();
 	}
 #endif
 #if defined(ADC2)
-	if (ADCx == ADC2){
+	if (ADCx == ADC2) {
 		__HAL_RCC_ADC2_CLK_ENABLE();
 	}
 #endif
 #if defined(ADC3)
-	if (ADCx == ADC3){
+	if (ADCx == ADC3) {
 		__HAL_RCC_ADC3_CLK_ENABLE();
 	}
 #endif


### PR DESCRIPTION
there is revised version of above rejected patch according to your rigogous rule.