### PR TITLE
Removed an unnecessary argument.

### DIFF
--- a/00-STM32_LIBRARIES/fatfs/drivers/fatfs_sd.c
+++ b/00-STM32_LIBRARIES/fatfs/drivers/fatfs_sd.c
@@ -120,7 +120,7 @@ static void xmit_spi_multi (
 		}
 	} while (btx > 0);
 #else
-	TM_SPI_WriteMulti(FATFS_SPI, buff, 0xFF, btx);
+	TM_SPI_WriteMulti(FATFS_SPI, buff, btx);
 #endif
 }
 #endif


### PR DESCRIPTION
Hello,

I found that is too many arguments to the `TM_SPI_WriteMulti()` call. And its implementation is a below:
> void TM_SPI_WriteMulti(SPI_TypeDef* SPIx, uint8_t* dataOut, uint32_t count);

I think that like a copy-and-paste mistake. Do you?