### PR TITLE
Added HAL_ADC_STATE_READY to checking conversion of a regular channel…

### DIFF
--- a/00-STM32_LIBRARIES/tm_stm32_adc.c
+++ b/00-STM32_LIBRARIES/tm_stm32_adc.c
@@ -172,7 +172,8 @@ uint16_t TM_ADC_Read(ADC_TypeDef* ADCx, TM_ADC_Channel_t channel) {
 	HAL_ADC_PollForConversion(&AdcHandle, 10);
 
 	/* Check if the continous conversion of regular channel is finished */
-	if (HAL_ADC_GetState(&AdcHandle) == HAL_ADC_STATE_EOC_REG) {
+	if ((HAL_ADC_GetState(&AdcHandle) == HAL_ADC_STATE_EOC_REG)
+	    || (HAL_ADC_GetState(&AdcHandle) == (HAL_ADC_STATE_EOC_REG | HAL_ADC_STATE_READY))) {
 		/* Get the converted value of regular channel */
 		return HAL_ADC_GetValue(&AdcHandle);
 	}


### PR DESCRIPTION
After called `HAL_ADC_PollForConversion()`, ADC state can have both `HAL_ADC_STATE_REG_EOC` and `HAL_ADC_STATE_READY` like below situation:
https://github.com/MaJerle/stm32fxxx_hal_libraries/blob/b295f87c649cccf0c27bcd6f8f3695666fdde571/00-HAL_DRIVERS/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_adc.c#L634-L655
So, Added `HAL_ADC_STATE_READY` to the code of checking conversion of a regular channel finished.